### PR TITLE
Remove Dispose method from StatementResult

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -453,32 +453,6 @@ namespace Neo4j.Driver.Tests
             }
         }
 
-        public class DisposeMethod
-        {
-            [Fact]
-            public void ShouldConsumeRecordStream()
-            {
-                var result = ResultCreator.CreateResult(1, 2);
-
-                result.Dispose();
-
-                result.AtEnd.Should().BeTrue();
-                result.Position.Should().Be(2);
-                result.GetEnumerator().MoveNext().Should().BeFalse();
-                result.GetEnumerator().Current.Should().BeNull();
-            }
-
-            [Fact]
-            public void ShouldPullSummary()
-            {
-                int getSummaryCalled = 0;
-                var result = ResultCreator.CreateResult(1, 0, () => { getSummaryCalled++; return new FakeSummary(); });
-
-                result.Dispose();
-                getSummaryCalled.Should().Be(1);
-            }
-        }
-
         private class FakeSummary : IResultSummary
         {
             public Statement Statement { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -93,21 +93,6 @@ namespace Neo4j.Driver.Internal.Result
             return Summary;
         }
 
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (!isDisposing)
-            {
-                return;
-            }
-            Consume();
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
         public IEnumerator<IRecord> GetEnumerator()
         {
             return _recordSet.Records.GetEnumerator();


### PR DESCRIPTION
To remove `StatementResult.Dispose` method for now
Leave the right to users to handle network actions themselves 
